### PR TITLE
Added dynamic battery widget

### DIFF
--- a/docs/content/usage/widgets/battery.md
+++ b/docs/content/usage/widgets/battery.md
@@ -2,7 +2,7 @@
 
 !!! Warning
 
-    The battery features are unavailable if the binary is compiled with the `battery` feature disabled!
+    The battery features are unavailable if the binary is compiled with the `battery` feature disabled or if there are no batteries on the system!
 
 The battery widget provides information about batteries on the system.
 

--- a/src/options.rs
+++ b/src/options.rs
@@ -10,6 +10,7 @@ use clap::ArgMatches;
 use layout_options::*;
 use regex::Regex;
 use serde::{Deserialize, Serialize};
+use starship_battery::Manager;
 use typed_builder::*;
 
 use crate::{
@@ -844,6 +845,14 @@ fn get_hide_table_gap(matches: &ArgMatches, config: &Config) -> bool {
 }
 
 fn get_use_battery(matches: &ArgMatches, config: &Config) -> bool {
+    if let Ok(battery_manager) = Manager::new() {
+        if let Ok(batteries) = battery_manager.batteries() {
+            if batteries.count() == 0 {
+                return false;
+            }
+        }
+    }
+
     if cfg!(feature = "battery") {
         if matches.is_present("battery") {
             return true;

--- a/src/options.rs
+++ b/src/options.rs
@@ -10,7 +10,10 @@ use clap::ArgMatches;
 use layout_options::*;
 use regex::Regex;
 use serde::{Deserialize, Serialize};
+
+#[cfg(feature = "battery")]
 use starship_battery::Manager;
+
 use typed_builder::*;
 
 use crate::{
@@ -845,6 +848,7 @@ fn get_hide_table_gap(matches: &ArgMatches, config: &Config) -> bool {
 }
 
 fn get_use_battery(matches: &ArgMatches, config: &Config) -> bool {
+    #[cfg(feature = "battery")]
     if let Ok(battery_manager) = Manager::new() {
         if let Ok(batteries) = battery_manager.batteries() {
             if batteries.count() == 0 {


### PR DESCRIPTION
## Description

For bottom to know that there are no batteries on the system, I added the `battery::Manager` to the options.rs file because here is the first moment bottom verifies battery configuration by reading the config file, which may or may not contain the battery field, but for a better UX, it doesn't matter what bottom finds in the config file now, if it doesn't retrieve battery data, it just ignores the battery widget all together.
If needed, it can be adjusted so that if the config file contains the battery field, it will still show the widget even without batteries on the system.

## Issue

#1  

## Testing

_If relevant, please state how this was tested. All changes **must** be tested to work:_
It was tested with and without config files on a PC without battery and on a laptop with and without battery installed.

_If this is a code change, please also indicate which platforms were tested:_

- [x] _Windows_
- [x] _macOS_
- [x] _Linux_

## Checklist

_If relevant, ensure the following have been met:_

- [x] _Areas your change affects have been linted using rustfmt (`cargo fmt`)_
- [x] _The change has been tested and doesn't appear to cause any unintended breakage_
- [x] _Documentation has been added/updated if needed (`README.md`, help menu, doc pages, etc.)_
- [ ] _The pull request passes the provided CI pipeline_
- [x] _There are no merge conflicts_
- [ ] _If relevant, new tests were added (don't worry too much about coverage)_
